### PR TITLE
Don't wait for BMH provisioning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
           dnf -q -y update
           dnf -q -y install python3-pip git ShellCheck
           pip3 install --upgrade pip
-          pip3 install --upgrade ansible-core kubernetes jmespath ansible-lint netaddr
+          pip3 install --upgrade ansible-core kubernetes ansible-lint netaddr
           ansible-galaxy collection install -U kubernetes.core community.general ansible.utils
           git config --global --add safe.directory /__w/openshift-edge-installer/openshift-edge-installer
       - uses: actions/checkout@v3

--- a/Containerfile
+++ b/Containerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 RUN microdnf -y update && microdnf -y install python3-pip && microdnf -y clean all && \
     pip install --upgrade pip && \
-    pip install --upgrade ansible-core kubernetes jmespath netaddr && \
+    pip install --upgrade ansible-core kubernetes netaddr && \
     ansible-galaxy collection install -U kubernetes.core community.general ansible.utils && \
     echo -e '#!/bin/bash\nansible-playbook /app/edge/edge-playbook.yaml --extra-vars "@/install-config.yaml"' > /usr/bin/edge && \
     chmod +x /usr/bin/edge && \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ After the installation of an edge cluster is complete, the edge cluster does not
   * If ODF is being installed, each node needs to have 2 disks (one for the OS, and one for ODF).
 * Local machine:
   * Install the following on your machine:
-    * Python modules: ```pip install --upgrade ansible-core kubernetes jmespath netaddr```
+    * Python modules: ```pip install --upgrade ansible-core kubernetes netaddr```
     * Ansible collections: ```ansible-galaxy collection install -U kubernetes.core community.general ansible.utils```
     * [oc binary](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz)
   * Alternatively, use the provided container. Usage instructions are included in the README for each playbook.

--- a/edge/roles/edge_install/tasks/main.yaml
+++ b/edge/roles/edge_install/tasks/main.yaml
@@ -147,6 +147,14 @@
     - name: Setup install config overrides
       ansible.builtin.include_tasks: install_config_overrides.yaml
 
+    - name: Create ClusterDeployment
+      kubernetes.core.k8s:
+        template: ClusterDeployment.yaml.j2
+        apply: true
+        state: present
+      register: k8s_result
+      until: k8s_result is not failed
+
     - name: Create AgentClusterInstall
       kubernetes.core.k8s:
         template: AgentClusterInstall.yaml.j2
@@ -159,14 +167,6 @@
         wait_timeout: 600
       vars:
         install_manifests_folder: "{{ edgeCluster.installManifestsFolder }}"
-      register: k8s_result
-      until: k8s_result is not failed
-
-    - name: Create ClusterDeployment
-      kubernetes.core.k8s:
-        template: ClusterDeployment.yaml.j2
-        apply: true
-        state: present
       register: k8s_result
       until: k8s_result is not failed
 

--- a/edge/roles/edge_install/tasks/main.yaml
+++ b/edge/roles/edge_install/tasks/main.yaml
@@ -152,6 +152,11 @@
         template: AgentClusterInstall.yaml.j2
         apply: true
         state: present
+        wait: true
+        wait_condition:
+          type: SpecSynced
+          status: "True"
+        wait_timeout: 600
       vars:
         install_manifests_folder: "{{ edgeCluster.installManifestsFolder }}"
       register: k8s_result
@@ -170,6 +175,11 @@
         template: InfraEnv.yaml.j2
         apply: true
         state: present
+        wait: true
+        wait_condition:
+          type: ImageCreated
+          status: "True"
+        wait_timeout: 600
       register: k8s_result
       until: k8s_result is not failed
 

--- a/edge/roles/edge_install/tasks/main.yaml
+++ b/edge/roles/edge_install/tasks/main.yaml
@@ -184,16 +184,6 @@
       register: create_bmh
       until: create_bmh is not failed
 
-    - name: Wait for BareMetalHosts to provision
-      kubernetes.core.k8s_info:
-        api_version: metal3.io/v1alpha1
-        kind: BareMetalHost
-        namespace: "{{ metadata.name }}"
-      register: bmh_list
-      until: bmh_list | community.general.json_query('resources[*].status.provisioning.state') | unique == ["provisioned"]
-      retries: 30
-      delay: 20
-
     - name: Get Events URL
       kubernetes.core.k8s_info:
         api_version: extensions.hive.openshift.io/v1beta1

--- a/edge/roles/edge_post_install/tasks/kubeconfig.yaml
+++ b/edge/roles/edge_post_install/tasks/kubeconfig.yaml
@@ -6,7 +6,7 @@
     namespace: "{{ metadata.name }}"
   register: aci
   until: aci.resources[0].spec.clusterMetadata.adminKubeconfigSecretRef.name is defined
-  retries: 60
+  retries: 40
   delay: 60
 
 - name: Get kubeconfig

--- a/edge/roles/edge_post_install/tasks/kubeconfig.yaml
+++ b/edge/roles/edge_post_install/tasks/kubeconfig.yaml
@@ -6,7 +6,7 @@
     namespace: "{{ metadata.name }}"
   register: aci
   until: aci.resources[0].spec.clusterMetadata.adminKubeconfigSecretRef.name is defined
-  retries: 30
+  retries: 60
   delay: 60
 
 - name: Get kubeconfig


### PR DESCRIPTION
With the new "converged flow" in 4.12, the BareMetalHosts don't mark themselves as "provisioned" until they write the OS image and reboot.

On a multi-node cluster, the bootstrap node doesn't reboot itself until very late in the install process and is thus in the "provisioning" state for almost the entire process.